### PR TITLE
Stops using python 2.7 since reached EOL

### DIFF
--- a/editors/atom/Makefile
+++ b/editors/atom/Makefile
@@ -59,7 +59,7 @@ RUN_DEPENDS=	git:devel/git \
 TEST_DEPENDS=	bash:shells/bash
 
 USES=		desktop-file-utils gl gnome jpeg localbase:ldflags pkgconfig \
-		python:2.7 shebangfix xorg
+		python shebangfix xorg
 
 USE_GITHUB=	yes
 


### PR DESCRIPTION
This makes the compiler to use the python version in the system, so it makes it compatible with FreeBSD 13.0 (that has python 3.7 available in ports) and also previous versions of FreeBSD (even if they happen to use Python 2.7)